### PR TITLE
various packages: make it cc-neutral

### DIFF
--- a/core/zlib/build
+++ b/core/zlib/build
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+export CFLAGS="$CFLAGS -fPIC"
+
 ./configure \
     --prefix=/usr \
     --libdir=/usr/lib \

--- a/extra/libvpx/build
+++ b/extra/libvpx/build
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+export CC="${CC:-cc}"
+export CXX="${CXX:-c++}"
+
 patch -p1 < fix-busybox-diff.patch
 
 # Remove the perl requirement from configure
@@ -13,6 +16,7 @@ sed -i 's/perl/:/g' configure
     --enable-vp9 \
     --enable-experimental \
     --enable-runtime-cpu-detect \
+    --target=x86_64-linux-gcc \
     --enable-shared \
     --enable-postproc \
     --enable-pic \

--- a/extra/x264/build
+++ b/extra/x264/build
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+export CC="${CC:-cc}"
+export CXX="${CC:-c++}"
+
 patch -p1 < x264-no-bash.patch
 
 ./configure \

--- a/extra/xfsprogs/build
+++ b/extra/xfsprogs/build
@@ -26,6 +26,9 @@ export LDFLAGS="$LDFLAGS -L$PWD/libinih/lib"
 # Remove incorrect bash dependency.
 sed -i 's/bash/sh/' install-sh
 
+# Explicitly include <signal.h> instead of implicit inclusion.
+sed -i '1i#include <signal.h>' include/linux.h
+
 ./configure \
     --prefix=/usr \
     --sbindir=/usr/bin \


### PR DESCRIPTION
## Description

Self-explanatory.

For libvpx, so unfortunately if we use just `$CC`, we'll have to regenerate the files, and if gcc is not detected, we'll lose significant advantages of using x86_64-specific CPU instruction set, like SSE2, so we have to add `--target=x86_64-linux-gcc` to the build system. I'll blame this on the build system, as usual.

For xfsprogs, looks like it's about https://freenode.logbot.info/kisslinux/20210326#c7396048