### PR TITLE
wpa_supplicant: actually install manpages

### DIFF
--- a/extra/wpa_supplicant/build
+++ b/extra/wpa_supplicant/build
@@ -15,6 +15,5 @@ cd wpa_supplicant
 make LIBDIR=/usr/lib BINDIR=/usr/bin DRV_LIBS="$CFLAGS" CC="${CC:-cc}"
 make LIBDIR=/usr/lib BINDIR=/usr/bin DESTDIR="$1" install
 
-install -Dm644 doc/docbook/*.8 "$1/usr/share/man/man8"
-install -Dm644 doc/docbook/*.5 "$1/usr/share/man/man5"
-
+install -Dm644 -t "$1/usr/share/man/man8" doc/docbook/*.8
+install -Dm644 -t "$1/usr/share/man/man5" doc/docbook/*.5


### PR DESCRIPTION
f7b634bd installed the manpages to a single file (`/usr/share/man/man{5,8}`) rather than the directories.