### PR TITLE
Explicitly specify DESTDIR when installing

### DIFF
--- a/core/curl/build
+++ b/core/curl/build
@@ -27,4 +27,4 @@ mv -f _ src/Makefile.in
     --without-zstd
 
 make
-make install
+make DESTDIR="$1" install

--- a/core/flex/build
+++ b/core/flex/build
@@ -6,7 +6,7 @@
     ac_cv_func_realloc_0_nonnull=yes
 
 make
-make install
+make DESTDIR="$1" install
 
 ln -s flex "$1/usr/bin/lex"
 

--- a/core/gcc/build
+++ b/core/gcc/build
@@ -55,7 +55,7 @@ esac
     "${bootstrap:---enable-bootstrap}"
 
 make
-make install
+make DESTDIR="$1" install
 
 # Save 35MB.
 find "$1" -name libgtkpeer.a  -exec rm -f {} +

--- a/core/git/build
+++ b/core/git/build
@@ -23,6 +23,6 @@ EOF
     ac_cv_fread_reads_directories=yes
 
 make LIBS="$(curl-config --static-libs) libgit.a reftable/libreftable.a xdiff/lib.a -lz"
-make install
+make DESTDIR="$1" install
 
 cp -Rf man "$1/usr/share/man"

--- a/core/grub/build
+++ b/core/grub/build
@@ -47,7 +47,7 @@ build_grub() (
         "$@"
 
     make
-    make install
+    make DESTDIR="$1" install
 )
 
 build_grub --with-platform=pc

--- a/core/m4/build
+++ b/core/m4/build
@@ -6,4 +6,4 @@ export CFLAGS="$CFLAGS -static"
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/core/make/build
+++ b/core/make/build
@@ -6,4 +6,4 @@ export CFLAGS="$CFLAGS -static"
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/core/musl/build
+++ b/core/musl/build
@@ -10,7 +10,7 @@
 #   --enable-debug
 
 make
-make install
+make DESTDIR="$1" install
 
 mkdir -p "$1/usr/bin"
 ln -s  /usr/lib/ld-musl-x86_64.so.1 "$1/usr/bin/ldd"

--- a/core/openssl/build
+++ b/core/openssl/build
@@ -27,5 +27,5 @@ cp -f update-certdata.sh "$1/etc/ssl"
         --with-openssl="$1/usr"
 
     make
-    make install
+    make DESTDIR="$1" install
 )

--- a/core/xz/build
+++ b/core/xz/build
@@ -6,4 +6,4 @@
     --disable-nls
 
 make
-make install
+make DESTDIR="$1" install

--- a/core/zlib/build
+++ b/core/zlib/build
@@ -6,4 +6,4 @@ export CFLAGS="$CFLAGS -fPIC"
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/adwaita-icon-theme/build
+++ b/extra/adwaita-icon-theme/build
@@ -4,4 +4,4 @@
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/alsa-lib/build
+++ b/extra/alsa-lib/build
@@ -5,4 +5,4 @@
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/alsa-utils/build
+++ b/extra/alsa-utils/build
@@ -10,4 +10,4 @@
     --disable-nls
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/bkeymaps/build
+++ b/extra/bkeymaps/build
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-make install
+make DESTDIR="$1" install
 
 cp -fr colemak "$1/usr/share/bkeymaps"
 

--- a/extra/cairo/build
+++ b/extra/cairo/build
@@ -23,4 +23,4 @@ sh ./configure \
     --disable-gtk-doc-html
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/cmake/build
+++ b/extra/cmake/build
@@ -24,7 +24,7 @@ else
         --system-bzip2
 
     make
-    make install
+    make DESTDIR="$1" install
 fi
 
 rm -rf \

--- a/extra/dosfstools/build
+++ b/extra/dosfstools/build
@@ -11,4 +11,4 @@ mv -f _ Makefile.in
     --enable-compat-symlinks
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/eiwd/build
+++ b/extra/eiwd/build
@@ -7,7 +7,7 @@
     --disable-dbus
 
 make
-make install
+make DESTDIR="$1" install
 
 cp -f iwd_passphrase "$1/usr/bin"
 

--- a/extra/expat/build
+++ b/extra/expat/build
@@ -8,7 +8,7 @@
     --without-docbook
 
 make
-make install
+make DESTDIR="$1" install
 
 # Remove documentation (Changelogs, etc).
 rm -rf "${1:?}/usr/share"

--- a/extra/ffmpeg/build
+++ b/extra/ffmpeg/build
@@ -30,6 +30,6 @@
     --x86asmexe=nasm \
 
 make
-make install
+make DESTDIR="$1" install
 
 rm -rf "$1/usr/share/ffmpeg/examples"

--- a/extra/firefox/build
+++ b/extra/firefox/build
@@ -17,7 +17,7 @@ mv widget/x11/keysym2ucs.h widget/gtk/keysym2ucs.h
         --program-suffix=-2.13
 
     make
-    make install
+    make DESTDIR="$1" install
 )
 
 # Build yasm for Firefox's sole use. Firefox is the only package which needs it

--- a/extra/fontconfig/build
+++ b/extra/fontconfig/build
@@ -16,4 +16,4 @@ mv -f _ src/Makefile.in
     --disable-nls
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/gnugrep/build
+++ b/extra/gnugrep/build
@@ -6,6 +6,6 @@ export CFLAGS="$CFLAGS -Wno-error -static"
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install
 
 cp -f src/grep "$1/usr/bin/ggrep"

--- a/extra/gnupg1/build
+++ b/extra/gnupg1/build
@@ -11,4 +11,4 @@ export CFLAGS="$CFLAGS -fcommon"
     --disable-nls
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/gtk+3/build
+++ b/extra/gtk+3/build
@@ -63,7 +63,7 @@ sh ./configure \
     --enable-gtk-doc-html=no
 
 make
-make install
+make DESTDIR="$1" install
 
 # GTK+3 on Wayland requires gsettings-desktop-schemas for gsettings to work
 # correctly. Under X11 it made use of xsettings but this is no longer the case.

--- a/extra/hicolor-icon-theme/build
+++ b/extra/hicolor-icon-theme/build
@@ -3,4 +3,4 @@
 ./configure \
     --prefix=/usr
 
-make install
+make DESTDIR="$1" install

--- a/extra/lame/build
+++ b/extra/lame/build
@@ -12,4 +12,4 @@ mv -f _ doc/Makefile.in
     --disable-gtktest
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/libass/build
+++ b/extra/libass/build
@@ -14,4 +14,4 @@ sh ./configure \
     --enable-fontconfig
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/libffi/build
+++ b/extra/libffi/build
@@ -6,7 +6,7 @@
     --with-pic
 
 make
-make install
+make DESTDIR="$1" install
 
 # Maintain compatibility and avoid the need
 # for rebuilds of all packages linking to

--- a/extra/libogg/build
+++ b/extra/libogg/build
@@ -7,4 +7,4 @@ make -C src
 make -C include install
 make -C src     install
 
-make install-m4dataDATA install-pkgconfigDATA
+make DESTDIR="$1" install-m4dataDATA install-pkgconfigDATA

--- a/extra/libpng/build
+++ b/extra/libpng/build
@@ -6,4 +6,4 @@ patch -p1 < libpng-1.6.37-apng.patch
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/libtheora/build
+++ b/extra/libtheora/build
@@ -9,4 +9,4 @@ patch -p1 < fix-theoraenc.patch
 make
 make -C lib     install
 make -C include install
-make install-pkgconfigDATA
+make DESTDIR="$1" install-pkgconfigDATA

--- a/extra/libvorbis/build
+++ b/extra/libvorbis/build
@@ -8,5 +8,5 @@ make
 make -C lib     install
 make -C include install
 
-make install-m4dataDATA install-pkgconfigDATA
+make DESTDIR="$1" install-m4dataDATA install-pkgconfigDATA
 

--- a/extra/libvpx/build
+++ b/extra/libvpx/build
@@ -25,7 +25,7 @@ sh ./configure \
     --as=nasm
 
 make
-make install
+make DESTDIR="$1" install
 
 # ABI was bumped for command-line options. This symbolic link removes the need
 # for users to rebuild Firefox, etc. Will be removed as of next Firefox release.

--- a/extra/libwebp/build
+++ b/extra/libwebp/build
@@ -9,4 +9,4 @@
     --enable-libwebpdecoder
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/mdevd/build
+++ b/extra/mdevd/build
@@ -22,7 +22,7 @@ mkdir -p junk
     --with-include="$PWD/junk/usr/include"
 
 make
-make install
+make DESTDIR="$1" install
 
 mkdir -p "$1/etc/sv/mdevd"
 cp -f mdevd.conf "$1/etc"

--- a/extra/mutt/build
+++ b/extra/mutt/build
@@ -35,7 +35,7 @@ mv -f _ Makefile.in
     --with-sasl="$out/usr"
 
 make
-make install-exec
+make DESTDIR="$1" install-exec
 
 rm -f "$1/etc/mime.types"
 

--- a/extra/nasm/build
+++ b/extra/nasm/build
@@ -4,4 +4,4 @@
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/ncurses/build
+++ b/extra/ncurses/build
@@ -14,7 +14,7 @@
     --without-cxx-binding
 
 make
-make install
+make DESTDIR="$1" install
 
 # Force ncurses to link against wide-character ncurses library.
 for lib in ncurses form panel menu; do

--- a/extra/opendoas/build
+++ b/extra/opendoas/build
@@ -10,7 +10,7 @@ BINGRP="$(id -g)" \
     --without-pam
 
 make
-make install
+make DESTDIR="$1" install
 
 mkdir -p "$1/etc"
 cp -f doas.conf "$1/etc"

--- a/extra/openresolv/build
+++ b/extra/openresolv/build
@@ -6,4 +6,4 @@
     --sysconfdir=/etc
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/opus/build
+++ b/extra/opus/build
@@ -6,4 +6,4 @@
     --enable-float-approx
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/pcre/build
+++ b/extra/pcre/build
@@ -5,6 +5,6 @@
     --enable-unicode-properties
 
 make
-make install
+make DESTDIR="$1" install
 
 rm -rf "$1/usr/share/doc"

--- a/extra/perl/build
+++ b/extra/perl/build
@@ -34,7 +34,7 @@ export CFLAGS="$CFLAGS -DNO_POSIX_2008_LOCALE -D_GNU_SOURCE"
     -Dd_static_inline
 
 make
-make install
+make DESTDIR="$1" install
 
 # Remove all unneeded files.
 find "$1" -name \*.pod       -exec rm -f {} +

--- a/extra/pkgconf/build
+++ b/extra/pkgconf/build
@@ -5,7 +5,7 @@
     --sysconfdir=/etc
 
 make
-make install
+make DESTDIR="$1" install
 
 ln -s pkgconf "$1/usr/bin/pkg-config"
 

--- a/extra/python/build
+++ b/extra/python/build
@@ -24,7 +24,7 @@ done
     --without-doc-strings
 
 make EXTRA_CFLAGS="$CFLAGS -DTHREAD_STACK_SIZE=0x100000"
-make install
+make DESTDIR="$1" install
 
 ln -s python3 "$1/usr/bin/python"
 ln -s pip3    "$1/usr/bin/pip"

--- a/extra/sqlite/build
+++ b/extra/sqlite/build
@@ -11,4 +11,4 @@ export CPPFLAGS="$CPPFLAGS -DSQLITE_ENABLE_COLUMN_METADATA=1"
     ac_cv_search_readline=no \
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/strace/build
+++ b/extra/strace/build
@@ -5,4 +5,4 @@
     --disable-mpers
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/util-linux/build
+++ b/extra/util-linux/build
@@ -16,7 +16,7 @@
     --without-systemd
 
 make
-make install
+make DESTDIR="$1" install
 
 # Fix broken --sbindir.
 mv -f "$1/usr/sbin/"* "$1/usr/bin"

--- a/extra/vim/build
+++ b/extra/vim/build
@@ -17,4 +17,4 @@
     --without-x
 
 make
-make install
+make DESTDIR="$1" install

--- a/extra/x264/build
+++ b/extra/x264/build
@@ -10,4 +10,4 @@ patch -p1 < portability.patch
     --enable-shared
 
 make
-make install
+make DESTDIR="$1" install

--- a/wayland/libpciaccess/build
+++ b/wayland/libpciaccess/build
@@ -4,4 +4,4 @@
     --prefix=/usr
 
 make
-make install
+make DESTDIR="$1" install

--- a/wayland/pixman/build
+++ b/wayland/pixman/build
@@ -5,4 +5,4 @@
     --disable-gtk
 
 make
-make install
+make DESTDIR="$1" install


### PR DESCRIPTION
Kiss sets DESTDIR in the environment, but is clearer to explicitly pass it
into make. This matches the style of the community repo and also allows
these packages to be reused in other kiss-like package managers.

This patch was generated by
```
find . -name  build -exec sed -i 's/make install/make DESTDIR="$1" install/g' {} \+
```